### PR TITLE
Add support for 20MHz clock source

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ Returns `1` on success, `0` on failure.
 
 ### Set pins
 
-#### MCP2515
+#### MCP2515 / MCP25625
 
 Override the default `CS` and `INT` pins used by the library. **Must** be called before `CAN.begin(...)`.
 
@@ -47,7 +47,7 @@ This call is optional and only needs to be used if you need to change the defaul
 
 ### Set SPI Frequency
 
-**MCP2515 only**
+**MCP2515  / MCP25625 only**
 
 Override the default SPI frequency of 10 MHz used by the library. **Must** be called before `CAN.begin(...)`.
 
@@ -60,16 +60,20 @@ This call is optional and only needs to be used if you need to change the defaul
 
 ### Set Clock Frequency
 
-**MCP2515 only**
+**MCP2515  / MCP25625 only**
 
 Override the default clock source frequency that is connected to the MCP2515. **Must** be called before `CAN.begin(...)`.
 
 ```arduino
 CAN.setClockFrequency(clockFrequency);
 ```
- * `clockFrequency` - new clock frequency to use (`8E6`, `16E6`) connected to MCP2515, defaults to `16 Mhz`
+ * `clockFrequency` - new clock frequency to use (`8E6`, `16E6`, `20E6`) connected to MCP2515, defaults to `16 Mhz`
 
-This call is optional and only needs to be used if you need to change the clock source frequency connected to the MCP2515. Most shields have a 16 MHz clock source on board, some breakout boards have a 8 MHz source.
+This call is optional and only needs to be used if you need to
+change the clock source frequency connected to the MCP2515.
+Most shields have a 16 MHz clock source on board, some breakout
+boards have a 8 MHz source, and some MCP25625 boards use 20 MHz.
+If using 20 MHz, the 5E3 bps CAN bitrate is not avilable.
 
 ### End
 

--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ Returns `1` on success, `0` on failure.
 
 ### Set pins
 
-#### MCP2515 / MCP25625
+#### MCP2515 and MCP25625
 
 Override the default `CS` and `INT` pins used by the library. **Must** be called before `CAN.begin(...)`.
 
@@ -47,7 +47,7 @@ This call is optional and only needs to be used if you need to change the defaul
 
 ### Set SPI Frequency
 
-**MCP2515  / MCP25625 only**
+**MCP2515 and MCP25625 only**
 
 Override the default SPI frequency of 10 MHz used by the library. **Must** be called before `CAN.begin(...)`.
 
@@ -60,14 +60,15 @@ This call is optional and only needs to be used if you need to change the defaul
 
 ### Set Clock Frequency
 
-**MCP2515  / MCP25625 only**
+**MCP2515 and MCP25625 only**
 
 Override the default clock source frequency that is connected to the MCP2515. **Must** be called before `CAN.begin(...)`.
 
 ```arduino
 CAN.setClockFrequency(clockFrequency);
 ```
- * `clockFrequency` - new clock frequency to use (`8E6`, `16E6`, `20E6`) connected to MCP2515, defaults to `16 Mhz`
+ * `clockFrequency` - new clock frequency to use (`8E6`, `16E6`, `20E6`)
+connected to MCP2515/MCP25625 OSC pins, defaults to `16 Mhz`
 
 This call is optional and only needs to be used if you need to
 change the clock source frequency connected to the MCP2515.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ An Arduino library for sending and receiving data using CAN bus.
 
 * [Microchip MCP2515](http://www.microchip.com/wwwproducts/en/en010406) based boards/shields
   * [Arduino MKR CAN shield](https://store.arduino.cc/arduino-mkr-can-shield)
+* Microchip MCP25625 based boards/shields
 * [Espressif ESP32](http://espressif.com/en/products/hardware/esp32/overview)'s built-in [SJA1000](https://www.nxp.com/products/analog/interfaces/in-vehicle-network/can-transceiver-and-controllers/stand-alone-can-controller:SJA1000T) compatible CAN controller with an external 3.3V CAN transceiver
 
-### Microchip MCP2515 wiring
+### Microchip MCP2515/MCP25625 wiring
 
 | Microchip MCP2515 | Arduino |
 | :---------------: | :-----: |
@@ -23,7 +24,9 @@ An Arduino library for sending and receiving data using CAN bus.
 
 `CS` and `INT` pins can be changed by using `CAN.setPins(cs, irq)`. `INT` pin is optional, it is only needed for receive callback mode. If `INT` pin is used, it **must** be interrupt capable via [`attachInterrupt(...)`](https://www.arduino.cc/en/Reference/AttachInterrupt).
 
-**NOTE**: Logic level converters must be used for boards which operate at 3.3V.
+**NOTE**: Logic level converters must be used for boards MCP2515
+which operate at 3.3V. The MCP25625 can run on 3.3V or 5V power,
+resolving this issue.
 
 ### Espressif ESP32 wiring
 

--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -88,6 +88,10 @@ int MCP2515Class::begin(long baudRate, bool stayInConfigurationMode)
     return 0;
   }
 
+  if( (baudRate == 5E3) && (_clockFrequency == 20E6) )
+    // with a 20MHz clock, the minimum baud rate is 6.25kHz
+    return 0;
+
   const struct {
     long clockFrequency;
     long baudRate;
@@ -118,7 +122,21 @@ int MCP2515Class::begin(long baudRate, bool stayInConfigurationMode)
     { (long)16E6,   (long)20E3, { 0x0f, 0xff, 0x87 } },
     { (long)16E6,   (long)10E3, { 0x1f, 0xff, 0x87 } },
     { (long)16E6,    (long)5E3, { 0x3f, 0xff, 0x87 } },
+
+    { (long)20E6, (long)1000E3, { 0x40, 0xd2, 0x82 } }, // 10 Tq, sp 70%, sjw=2, 3 samples (tested)
+    { (long)20E6,  (long)500E3, { 0x40, 0xf5, 0x85 } }, // 20 Tq, sp 70%, sjw=2, 3 samples (tested)
+    { (long)20E6,  (long)250E3, { 0x41, 0xf5, 0x85 } }, // 20 Tq, sp 70%, sjw=2, 3 samples (tested)
+    { (long)20E6,  (long)200E3, { 0x41, 0xff, 0x87 } }, // 25 Tq, sp 68%, sjw=2, 3 samples
+    { (long)20E6,  (long)125E3, { 0x43, 0xf5, 0x85 } }, // 20 Tq, sp 70%, sjw=2, 3 samples (tested)
+    { (long)20E6,  (long)100E3, { 0x44, 0xf5, 0x85 } }, // 20 Tq, sp 70%, sjw=2, 3 samples
+    { (long)20E6,   (long)80E3, { 0x44, 0xff, 0x87 } }, // 25 Tq, sp 70%, sjw=2, 3 samples
+    { (long)20E6,   (long)50E3, { 0x49, 0xf5, 0x85 } }, // 20 Tq, sp 70%, sjw=2, 3 samples
+    { (long)20E6,   (long)40E3, { 0x49, 0xff, 0x87 } }, // 25 Tq, sp 68%, sjw=2, 3 samples
+    { (long)20E6,   (long)20E3, { 0x58, 0xf5, 0x85 } }, // 20 Tq, sp 70%, sjw=2, 3 samples
+    { (long)20E6,   (long)10E3, { 0x71, 0xf5, 0x85 } }, // 20 Tq, sp 70%, sjw=2, 3 samples
+    { (long)20E6,    (long)5E3, { 0x7f, 0xff, 0x87 } }, // 6.25kHz is as slow as it can go
   };
+  //https://www.kvaser.com/support/calculators/bit-timing-calculator/  (use MCP2510 option)
 
   const uint8_t* cnf = NULL;
 


### PR DESCRIPTION
A device that I am working with (Digilent 410-353 PMOD CAN CONTROLLER) uses a 20 MHz oscillator. The Arduino-CAN driver is working fine on this device (which uses a register compatible MCP25625 controller chip) except that all the baud rates are 25% high. 
This change adds another section to the config table to support the 20MHz oscillator rate.
